### PR TITLE
chore: add dependency update cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "chore(deps):"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "chore(deps):"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
## Summary
- Add Dependabot config for npm and GitHub Actions updates.
- Add a 7-day cooldown for routine updates to reduce supply-chain ingestion risk.

## Verification
- Ruby YAML parse for .github/dependabot.yml
- supply-chain-advisory-helper scan against this worktree: no IOCs found

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.37 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 46m and 107,336 tokens on this as a headless worker.
