### PR TITLE
chore: add Renovate dependency cooldown

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,20 @@
+{
+  "extends": ["config:recommended"],
+  "dependencyDashboard": true,
+  "labels": ["dependencies"],
+  "schedule": ["before 5am on monday"],
+  "timezone": "UTC",
+  "minimumReleaseAge": "7 days",
+  "rangeStrategy": "bump",
+  "commitMessagePrefix": "chore(deps):",
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions dependencies"
+    },
+    {
+      "matchDatasources": ["npm"],
+      "groupName": "npm dependencies"
+    }
+  ]
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,11 +2,11 @@
   "extends": ["config:recommended"],
   "dependencyDashboard": true,
   "labels": ["dependencies"],
-  "schedule": ["before 5am on monday"],
+  "schedule": ["before 5am on Monday"],
   "timezone": "UTC",
   "minimumReleaseAge": "7 days",
   "rangeStrategy": "bump",
-  "commitMessagePrefix": "chore(deps):",
+  "commitMessagePrefix": "chore(deps): ",
   "packageRules": [
     {
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
## Summary
- Add Renovate configuration for npm and GitHub Actions dependency updates.
- Preserve the requested 7-day dependency cooldown with `minimumReleaseAge`.
- Group npm and GitHub Actions updates and label dependency PRs.

## Verification
- `python3 -m json.tool .github/renovate.json >/dev/null`

Replaces the invalid Dependabot cooldown approach from PR #4.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.22 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5
